### PR TITLE
fix: NaN/±inf poisoning guards across Φ, order-parameter, and coupling bridge

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -102,16 +102,25 @@ impl CouplingBridge {
     /// - **MarketMediated**: K(t) = K_base × signal, clamped to [k_min, k_max]
     /// - **Adaptive**: adjusts K toward target coherence using current_coherence
     pub fn update(&mut self, signal: f32, current_coherence: f32) -> f32 {
-        self.signal_history.push(signal);
-        // Bounded ring-buffer behavior — drop the oldest sample once we
-        // exceed the configured window. Without this `mean_signal`
-        // grew toward the all-time mean instead of the windowed mean
-        // its docstring promised, and memory leaked unbounded (#14).
-        if self.config.max_signal_history > 0
-            && self.signal_history.len() > self.config.max_signal_history
-        {
-            let drop = self.signal_history.len() - self.config.max_signal_history;
-            self.signal_history.drain(0..drop);
+        // Only record finite signals (#22). update() used to append the raw
+        // signal before branching on mode, so a single non-finite sample
+        // made mean_signal() return NaN forever — even in Static mode, which
+        // is documented to ignore signals entirely. Diagnostics now stay
+        // finite regardless of garbage input; an all-invalid history simply
+        // collapses to the neutral 1.0 mean_signal() already returns when
+        // empty.
+        if signal.is_finite() {
+            self.signal_history.push(signal);
+            // Bounded ring-buffer behavior — drop the oldest sample once we
+            // exceed the configured window. Without this `mean_signal`
+            // grew toward the all-time mean instead of the windowed mean
+            // its docstring promised, and memory leaked unbounded (#14).
+            if self.config.max_signal_history > 0
+                && self.signal_history.len() > self.config.max_signal_history
+            {
+                let drop = self.signal_history.len() - self.config.max_signal_history;
+                self.signal_history.drain(0..drop);
+            }
         }
 
         self.k_effective = match self.mode {
@@ -120,9 +129,25 @@ impl CouplingBridge {
                 (self.config.k_base * signal).clamp(self.config.k_min, self.config.k_max)
             }
             CouplingMode::Adaptive => {
-                let error = self.config.target_coherence - current_coherence;
-                let new_k = self.k_effective + self.config.adaptive_rate * error;
-                new_k.clamp(self.config.k_min, self.config.k_max)
+                // Reject a non-finite coherence sample (#19). Without this, a
+                // single NaN current_coherence makes `error`, then `new_k`,
+                // NaN; f32::clamp preserves NaN, so k_effective would stay
+                // NaN permanently and every later valid update would build on
+                // the poisoned value. Hold the last good coupling on invalid
+                // input (falling back to k_base if k_effective itself was
+                // somehow corrupted) so the bridge can recover.
+                let safe_prev = if self.k_effective.is_finite() {
+                    self.k_effective
+                } else {
+                    self.config.k_base
+                };
+                if current_coherence.is_finite() {
+                    let error = self.config.target_coherence - current_coherence;
+                    (safe_prev + self.config.adaptive_rate * error)
+                        .clamp(self.config.k_min, self.config.k_max)
+                } else {
+                    safe_prev.clamp(self.config.k_min, self.config.k_max)
+                }
             }
         };
 
@@ -298,6 +323,91 @@ mod tests {
             below.coupling(),
             0.1,
             "k_base below k_min must clamp at construction"
+        );
+    }
+
+    #[test]
+    fn adaptive_recovers_from_non_finite_coherence() {
+        // Regression for #19 — a single NaN coherence made error → new_k →
+        // NaN, and f32::clamp preserves NaN, so k_effective stayed NaN
+        // permanently. Now a non-finite coherence holds the last good
+        // coupling and later valid updates recover.
+        let mut bridge = CouplingBridge::new(
+            BridgeConfig {
+                k_base: 1.0,
+                adaptive_rate: 0.1,
+                target_coherence: 0.8,
+                ..Default::default()
+            },
+            CouplingMode::Adaptive,
+        );
+        let first = bridge.update(1.0, f32::NAN);
+        assert!(
+            first.is_finite(),
+            "NaN coherence must not poison coupling: {first}"
+        );
+        let second = bridge.update(1.0, 0.3);
+        assert!(
+            second.is_finite(),
+            "coupling must recover after a valid update: {second}"
+        );
+        assert!(bridge.coupling().is_finite());
+    }
+
+    #[test]
+    fn adaptive_holds_coupling_on_non_finite_coherence() {
+        // A non-finite coherence should freeze coupling at its last good
+        // value rather than drift (#19).
+        let mut bridge = CouplingBridge::new(
+            BridgeConfig {
+                k_base: 1.0,
+                adaptive_rate: 0.1,
+                target_coherence: 0.8,
+                ..Default::default()
+            },
+            CouplingMode::Adaptive,
+        );
+        let before = bridge.coupling();
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let k = bridge.update(1.0, bad);
+            assert!(
+                (k - before).abs() < 1e-6,
+                "coupling should hold on coherence {bad}: {before} → {k}"
+            );
+        }
+    }
+
+    #[test]
+    fn static_mode_stays_diagnostically_finite() {
+        // Regression for #22 — update() recorded the raw signal before
+        // branching on mode, so a NaN signal poisoned mean_signal() even
+        // though Static mode ignores signals for coupling. Non-finite
+        // signals are no longer stored.
+        let mut bridge = CouplingBridge::new(BridgeConfig::default(), CouplingMode::Static);
+        let k = bridge.update(f32::NAN, 0.5);
+        assert!(k.is_finite(), "static coupling stays finite: {k}");
+        assert!(
+            bridge.mean_signal().is_finite(),
+            "mean_signal must ignore non-finite signals; got {}",
+            bridge.mean_signal()
+        );
+        // A NaN-only history collapses to the neutral empty-history default.
+        assert!((bridge.mean_signal() - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn mean_signal_skips_non_finite_samples() {
+        // A finite sample interleaved with garbage still averages cleanly
+        // over just the finite samples (#22).
+        let mut bridge = CouplingBridge::new(BridgeConfig::default(), CouplingMode::MarketMediated);
+        bridge.update(2.0, 0.5);
+        bridge.update(f32::NAN, 0.5);
+        bridge.update(4.0, 0.5);
+        bridge.update(f32::INFINITY, 0.5);
+        assert!(
+            (bridge.mean_signal() - 3.0).abs() < 1e-5,
+            "mean over finite samples 2 and 4 = 3, got {}",
+            bridge.mean_signal()
         );
     }
 

--- a/src/iit.rs
+++ b/src/iit.rs
@@ -167,15 +167,25 @@ pub fn compute_phi(nodes: &[PhiNode]) -> PhiReport {
     let mut total_connections: usize = 0;
     let mut cross_partition: usize = 0;
 
-    // Only count edges that resolve to a real node. Pre-fix, stale or
-    // out-of-bounds indices were silently folded into the denominator,
-    // which depressed `integration` and `num_connections` for callers
-    // who couldn't tell their graph had drifted.
-    for node in nodes {
-        for &target in &node.connections {
-            if target >= nodes.len() {
-                continue;
-            }
+    // Normalize each node's edge list before counting: drop self-loops and
+    // collapse duplicate targets, and only count edges that resolve to a
+    // real node. Pre-fix, stale/out-of-bounds indices were silently folded
+    // into the denominator, which depressed `integration` and
+    // `num_connections` (kept here); and raw duplicate edges or self-loops
+    // inflated `total_connections` (density) — and could skew
+    // `integration` — letting malformed graph input overstate Φ without any
+    // genuine new inter-node structure (#20). A self-loop (`target == i`)
+    // never crosses a partition, so it only ever pads the denominator.
+    for (i, node) in nodes.iter().enumerate() {
+        let mut targets: Vec<usize> = node
+            .connections
+            .iter()
+            .copied()
+            .filter(|&target| target != i && target < nodes.len())
+            .collect();
+        targets.sort_unstable();
+        targets.dedup();
+        for target in targets {
             total_connections += 1;
             if nodes[target].partition != node.partition {
                 cross_partition += 1;
@@ -229,6 +239,14 @@ pub fn compute_phi(nodes: &[PhiNode]) -> PhiReport {
 pub fn compute_swarm_phi(order_parameter: f32, coherences: &[f32], has_chiral_agents: bool) -> f32 {
     let n = coherences.len();
     if n < 2 {
+        return 0.0;
+    }
+    // Reject non-finite inputs outright (#21). The `.max(0.0)` flooring
+    // below neutralizes NaN and negatives, but a `+∞` order_parameter or
+    // coherence survives `max` and then `.clamp(0.0, 15.0)` promotes it to
+    // the MAXIMUM swarm Φ of 15.0 — exactly backwards. A broken measurement
+    // must read as zero consciousness, not peak.
+    if !order_parameter.is_finite() || coherences.iter().any(|c| !c.is_finite()) {
         return 0.0;
     }
     // Floor each input contribution at zero before composing them so a
@@ -531,6 +549,67 @@ mod tests {
         // honor the upper bound.
         let phi = compute_swarm_phi(1.0, &[1.0; 50], true);
         assert!(phi <= 15.0, "swarm Φ must not exceed 15.0; got {}", phi);
+    }
+
+    #[test]
+    fn swarm_phi_non_finite_inputs_return_zero() {
+        // Regression for #21 — non-finite inputs used to be promoted to the
+        // MAXIMUM swarm Φ (15.0): .max(0.0) neutralizes NaN/negatives but a
+        // +∞ order_parameter or coherence survived it, and .clamp(0.0, 15.0)
+        // then pinned it at the ceiling. A broken measurement must read as
+        // zero, never peak consciousness.
+        assert_eq!(compute_swarm_phi(f32::NAN, &[0.9, 0.9], false), 0.0);
+        assert_eq!(compute_swarm_phi(f32::INFINITY, &[0.9, 0.9], false), 0.0);
+        assert_eq!(
+            compute_swarm_phi(f32::NEG_INFINITY, &[0.9, 0.9], false),
+            0.0
+        );
+        assert_eq!(compute_swarm_phi(0.8, &[0.9, f32::NAN], false), 0.0);
+        assert_eq!(compute_swarm_phi(0.8, &[0.9, f32::INFINITY], false), 0.0);
+        assert_eq!(
+            compute_swarm_phi(0.8, &[0.9, f32::NEG_INFINITY], false),
+            0.0
+        );
+        // A finite, valid swarm is unaffected by the guard.
+        assert!(compute_swarm_phi(0.9, &[0.9, 0.9], false) > 0.0);
+    }
+
+    #[test]
+    fn phi_ignores_duplicate_edges_and_self_loops() {
+        // Regression for #20 — duplicate targets and self-loops used to bump
+        // total_connections (and could skew integration), letting malformed
+        // graph input inflate Φ with no genuine new inter-node structure.
+        // The dirty graph must now match the equivalent simple graph exactly
+        // and never exceed it.
+        let clean = compute_phi(&[
+            PhiNode {
+                partition: 0,
+                connections: vec![1],
+            },
+            PhiNode {
+                partition: 1,
+                connections: vec![0],
+            },
+        ]);
+        let dirty = compute_phi(&[
+            PhiNode {
+                partition: 0,
+                connections: vec![1, 1, 0], // duplicate edge + self-loop
+            },
+            PhiNode {
+                partition: 1,
+                connections: vec![0, 0, 1], // duplicate edge + self-loop
+            },
+        ]);
+        assert_eq!(clean.num_connections, dirty.num_connections);
+        assert!((clean.integration - dirty.integration).abs() < 1e-6);
+        assert!((clean.phi - dirty.phi).abs() < 1e-6);
+        assert!(
+            dirty.phi <= clean.phi + 1e-6,
+            "self-loops/duplicates must not inflate Φ: clean={} dirty={}",
+            clean.phi,
+            dirty.phi
+        );
     }
 
     #[test]

--- a/src/kuramoto.rs
+++ b/src/kuramoto.rs
@@ -122,17 +122,33 @@ impl KuramotoModel {
         // the denominator can be small or even negative while the
         // numerator's magnitude grows. Floor-at-zero is the conservative
         // reading of "active distrust" (#17).
+        //
+        // Additionally drop any oscillator whose phase or weight is
+        // non-finite before it reaches the weighted sums (#23). A single
+        // NaN/±inf phase (via `phase.cos()`) or weight would otherwise
+        // poison `sum_cos`/`sum_sin`/`total_weight` and return `r = NaN`,
+        // violating the documented `r ∈ [0, 1]` contract. NaN weights were
+        // already neutralized by the `max(0.0)` above, but +inf weights and
+        // any non-finite phase were not. Invalid oscillators contribute
+        // nothing rather than corrupting the whole metric.
+        let is_finite = |o: &Oscillator| o.phase.is_finite() && o.weight.is_finite();
         let effective_weight = |o: &Oscillator| o.weight.max(0.0);
-        let total_weight: f32 = oscillators.iter().map(effective_weight).sum();
+        let total_weight: f32 = oscillators
+            .iter()
+            .filter(|o| is_finite(o))
+            .map(effective_weight)
+            .sum();
         if total_weight == 0.0 {
             return OrderParameter { r: 0.0, psi: 0.0 };
         }
         let sum_cos: f32 = oscillators
             .iter()
+            .filter(|o| is_finite(o))
             .map(|o| effective_weight(o) * o.phase.cos())
             .sum();
         let sum_sin: f32 = oscillators
             .iter()
+            .filter(|o| is_finite(o))
             .map(|o| effective_weight(o) * o.phase.sin())
             .sum();
         // Final defensive clamp to the documented [0, 1] range — floating
@@ -588,5 +604,59 @@ mod tests {
         ];
         let r = KuramotoModel::order_parameter(&oscs).r;
         assert_eq!(r, 0.0);
+    }
+
+    #[test]
+    fn order_parameter_rejects_non_finite_phase() {
+        // Regression for #23 — a single NaN/±inf phase used to poison the
+        // weighted sums (via phase.cos()/sin()) and return r = NaN, breaking
+        // the documented r ∈ [0, 1] contract. Non-finite oscillators are now
+        // excluded from the metric entirely.
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let oscs = vec![
+                Oscillator::with_weight(bad, 0.0, 1.0),
+                Oscillator::with_weight(0.0, 0.0, 1.0),
+            ];
+            let op = KuramotoModel::order_parameter(&oscs);
+            assert!(
+                op.r.is_finite() && (0.0..=1.0).contains(&op.r),
+                "non-finite phase {bad} must not poison r; got {}",
+                op.r
+            );
+            assert!(op.psi.is_finite(), "psi must stay finite for phase {bad}");
+        }
+    }
+
+    #[test]
+    fn order_parameter_rejects_non_finite_weight() {
+        // Regression for #23 — NaN/±inf weights are dropped rather than
+        // corrupting total_weight or the weighted sums. NaN was already
+        // neutralized by the #17 max(0.0) flooring; +inf was not (it
+        // survived max() and blew up the denominator).
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let oscs = vec![
+                Oscillator::with_weight(0.0, 0.0, bad),
+                Oscillator::with_weight(0.0, 0.0, 1.0),
+            ];
+            let op = KuramotoModel::order_parameter(&oscs);
+            assert!(
+                op.r.is_finite() && (0.0..=1.0).contains(&op.r),
+                "non-finite weight {bad} must not poison r; got {}",
+                op.r
+            );
+        }
+    }
+
+    #[test]
+    fn order_parameter_all_non_finite_returns_zero() {
+        // Every oscillator invalid → effective total weight zero → safe 0.0,
+        // never NaN (#23).
+        let oscs = vec![
+            Oscillator::with_weight(f32::NAN, 0.0, 1.0),
+            Oscillator::with_weight(0.0, 0.0, f32::INFINITY),
+        ];
+        let op = KuramotoModel::order_parameter(&oscs);
+        assert_eq!(op.r, 0.0);
+        assert_eq!(op.psi, 0.0);
     }
 }


### PR DESCRIPTION
## Summary

Metric-trust batch for the NaN-poisoning issues #18–#23. `consciousness-core` is the constellation's shared physics layer (path dependency of kannaka-memory, consumed across kuramoto/xi/wave/queen), so a single `NaN`/`±inf` slipping into a coherence or Φ score silently corrupts swarm-coherence decisions and every downstream dashboard. Each guard follows the precedent of `764faeb` / `311d04b`: **exclude or floor non-finite inputs, never emit a max score**, and every guard ships a regression test covering `NaN` / `+inf` / `-inf` / empty input.

Before writing anything I probed the *current* source (several of these overlap with already-landed fixes for #8/#9/#13/#17), so the fixes target only the paths that are still live.

## Fixes

Fixes #19
Fixes #20
Fixes #21
Fixes #22
Fixes #23

| Issue | Function | Live bug (confirmed by probe) | Fix |
|------|----------|-------------------------------|-----|
| #23 | `kuramoto::order_parameter` | NaN **weight** already tamed by #17's `max(0.0)`, but a non-finite **phase** (via `cos`/`sin`) and a `+inf` weight still returned `r = NaN` | Drop oscillators with non-finite phase or weight before the weighted sums |
| #21 | `iit::compute_swarm_phi` | `#9`'s `max(0.0)` tamed NaN/negatives, but `+inf` survived it and `.clamp(0.0, 15.0)` promoted a broken input to the **maximum** swarm Φ (15.0) | Return `0.0` on any non-finite `order_parameter` or coherence |
| #20 | `iit::compute_phi` | Duplicate edges + self-loops inflated Φ `0.295 → 0.341` (connections `2 → 6`) | Normalize each node's edges: drop self-loops, dedup targets |
| #19 | `bridge::update` (Adaptive) | One NaN `current_coherence` poisoned `k_effective` permanently (`f32::clamp` preserves NaN) | Reject non-finite coherence, hold last good coupling, recover on next valid update |
| #22 | `bridge::update` | A non-finite signal was recorded before the mode branch, so `mean_signal()` returned NaN forever — even in Static mode, which ignores signals | Only record finite signals |

## Closed as already-fixed

**#18** (ragged-weight `sync()` panic) is a duplicate of the already-fixed **#13**: the shape validation at `kuramoto.rs:195-199` drops the malformed matrix and the existing `sync_with_ragged_weights_does_not_panic` test covers it. The exact #18 repro produced a finite `0.965` with no panic. Closed separately with that evidence.

## Verification

Mirrored every CI gate locally on Windows (stable toolchain):

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --release` — 73 unit + 5 integration pass
- `cargo test --release --all-features` — 73 + 9 + 5 pass

New regression tests: `order_parameter_rejects_non_finite_phase`, `order_parameter_rejects_non_finite_weight`, `order_parameter_all_non_finite_returns_zero`, `swarm_phi_non_finite_inputs_return_zero`, `phi_ignores_duplicate_edges_and_self_loops`, `adaptive_recovers_from_non_finite_coherence`, `adaptive_holds_coupling_on_non_finite_coherence`, `static_mode_stays_diagnostically_finite`, `mean_signal_skips_non_finite_samples`.

## Integration check (kannaka-memory)

kannaka-memory's tree is dirty (another agent is mid-work on `src/nats.rs`), so per protocol I ran `cargo check` there instead of the full suite. `consciousness-core` compiles cleanly as its path dependency; kannaka-memory imports only `iit::ConsciousnessLevel`, `wave`, and `metrics` — none of which changed signature. Its build currently fails **only** on the co-worker's in-progress `NatsSubscription` struct in `src/nats.rs`, unrelated to this change. No public API in this crate changed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>