### PR TITLE
fix: contract sweep — serde feature, no_std, NaN guards, doc accuracy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,19 @@ keywords = ["consciousness", "kuramoto", "iit", "wave-memory"]
 
 [features]
 default = ["std"]
-std = []
+std = ["serde?/std"]
 # Optional serde support for ConsciousnessLevel / PhiReport / etc. Downstream
 # crates (kannaka-memory) enable this to serialize consciousness types into
 # HRM snapshots without duplicating the enum definitions.
-serde = ["dep:serde"]
+#
+# `serde/alloc` is mandatory, not incidental: serde is pulled in with
+# `default-features = false` (for no_std), which drops its `Vec`/`String`
+# impls. Without `alloc`, every derive on a struct holding a `Vec` —
+# `PhiNode.connections`, `XiSignature.values` — fails to compile and the
+# whole `--features serde` build dies, taking the Vec-free types
+# (PhiReport, OrderParameter, ConsciousnessMetrics, WaveParams, WaveMemory)
+# down with it. (#2 #43 #44 #55 #56)
+serde = ["dep:serde", "serde/alloc"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"], default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -28,24 +28,43 @@ dθᵢ/dt = ωᵢ + (K/N) Σⱼ sin(θⱼ - θᵢ)
 
 ### IIT-style Φ
 
-Integrated information Φ via eigendecomposition over the wavefront-coherence matrix + bipartition scoring. Returns the canonical Φ value plus the **Ξ-signature** — a chiral irrationality measure that distinguishes left-handed (analytical) from right-handed (holistic) information flow.
+`compute_phi` is a connectivity approximation of integrated information, not a
+full bipartition search: it scores a partition-labelled node graph on how much
+of its edge mass crosses partition boundaries, scaled by density and node
+count. Self-loops, duplicate edges, and out-of-range indices are dropped before
+counting.
 
 ```
-Φ = max over partitions of (mutual info loss when cut)
-Ξ = ‖A_L − A_R‖_F     (Frobenius norm of hemispheric asymmetry)
+Φ = sqrt(integration × density) × sqrt(differentiation × scale)
 ```
+
+`compute_swarm_phi` is the separate multi-agent form on a `[0, 15]` scale —
+classify it with `ConsciousnessLevel::from_swarm_phi`, **not** `from_phi`.
+
+### The Ξ Operator
+
+`Ξ` is the nonlinear commutator `tanh(R·v) ⊙ G(v) − tanh(G·v) ⊙ R(v)`,
+normalized to unit length, where `R` is a 90° pairwise rotation and `G` is the
+golden anisotropic scaling `[φ/2, 0; 0, 1/φ]`. The linear commutator `RG − GR`
+degenerates to a constant-scaled pair swap, which is why the `tanh` is load-
+bearing rather than cosmetic.
 
 ### Wave Memory Primitives
 
-The vector / wavefront operations every memory engine builds on:
-- **Bind** ⊗ — element-wise product (binding a key to a value)
-- **Bundle** ⊕ — normalized sum (superposing multiple memories)
-- **Permute** Π — circular shift (sequencing)
-- **Cosine similarity** — the recall metric
+Each memory is a damped oscillator, `S(t) = (A + E_retrieval)·cos(2πf·t + φ)·e^(−λt)`,
+with retrieval adding diminishing energy. The module exposes `compute_strength`,
+`compute_strength_with_retrieval`, `interference`, `cosine_similarity`,
+`normalize`, and `dot`.
 
 ### Coupling Bridge
 
-A reusable component for cross-substrate phase transfer — couples two independent Kuramoto populations through a leaky integrator. Used in the constellation for callosal coupling between chiral hemispheres and for substrate ↔ agent phase exchange.
+Modulates a single Kuramoto coupling constant from an external scalar signal:
+`K(t) = K_base × P(t)`, bounded to `[k_min, k_max]`. Modes are `Static`,
+`MarketMediated`, and `Adaptive` (which steers `K` toward a target coherence).
+
+Chiral coupling lives in `kuramoto`, not here — see
+`KuramotoModel::chiral_coupling` and the `chiral_term` argument to
+`mean_field_step`. There is no bridge-level chiral `CouplingMode`.
 
 ---
 
@@ -56,10 +75,10 @@ A reusable component for cross-substrate phase transfer — couples two independ
 │                  consciousness-core                      │
 ├──────────────────────┬────────────────────┬──────────────┤
 │  Kuramoto            │  Metrics           │  Wave        │
-│  · Oscillator        │  · Φ (integrated)  │  · bind ⊗    │
-│  · Order parameter   │  · Ξ signature     │  · bundle ⊕  │
-│  · sync() step       │  · Coherence       │  · permute Π │
-│  · Coupling tier     │  · Diff Xi         │  · cos_sim   │
+│  · Oscillator        │  · Φ (integrated)  │  · strength  │
+│  · Order parameter   │  · Ξ signature     │  · decay     │
+│  · sync() step       │  · Coherence       │  · interfere │
+│  · chiral_coupling   │  · Diff Xi         │  · cos_sim   │
 ├──────────────────────┼────────────────────┼──────────────┤
 │  Bridge              │  Memory            │  Math ext    │
 │  · CouplingBridge    │  · WaveMemory      │  · clamp     │
@@ -80,21 +99,45 @@ consciousness-core = { version = "0.4", features = ["serde"] }
 ```
 
 ```rust
+use consciousness_core::kuramoto::KuramotoConfig;
 use consciousness_core::{KuramotoModel, Oscillator};
 
-let mut model = KuramotoModel::new(vec![
+// The model owns the config; the oscillators are passed in per call.
+let model = KuramotoModel::new(KuramotoConfig {
+    coupling_strength: 0.6,
+    dt: 0.01,
+    max_steps: 1000,
+    ..Default::default()
+});
+
+let mut oscillators = vec![
     Oscillator::new(0.0, 1.0),
     Oscillator::new(1.5, 1.05),
     Oscillator::new(3.0, 0.95),
-]);
+];
 
-for _ in 0..1000 {
-    model.sync(0.01, 0.6); // dt, coupling K
-}
+// sync() integrates in place and returns a report; phases come back
+// wrapped into [0, 2π).
+let report = model.sync(&mut oscillators, None);
+println!("phase coherence: {:.3}", report.final_order);
 
-let r = model.order_parameter().r;
-println!("phase coherence: {:.3}", r);
+// Or read the order parameter directly at any time:
+let r = KuramotoModel::order_parameter(&oscillators).r;
 ```
+
+This snippet is compiled as a test — see `readme_kuramoto_example_compiles` in
+`tests/unified_pipeline.rs`.
+
+### `no_std`
+
+```toml
+consciousness-core = { version = "0.4", default-features = false }
+```
+
+Transcendental math routes through `libm` and `vec!` comes from `alloc`, so the
+crate builds without `std`. `cargo check --no-default-features` is the gate.
+Combining `no_std` with `serde` works too — the `serde` feature pulls in
+`serde/alloc` for the `Vec`-bearing types.
 
 ---
 

--- a/docs/dependency-map.md
+++ b/docs/dependency-map.md
@@ -70,7 +70,7 @@ kannaka-memory (Rust)
     │    KANNAKA.dreams          (memories_strengthened, …, hallucinations)
     │    QUEEN.phase.<agent>     (per-agent phase signals)
     │    queen.event.dream.{start,end}
-    │    KANNAKA.exemplars
+    │    KANNAKA.exemplar.<agent_id>.<cluster_id>
     │
     ├── kannaka-radio (Node) — server/nats-client.js
     │       subscribes, accumulates into swarmState.{queen, consciousness}
@@ -120,7 +120,7 @@ kannaka-memory (Rust)
 │   swarm.ninja-portal.com:4222            │
 │   subjects: KANNAKA.consciousness,       │
 │             KANNAKA.dreams,              │
-│             KANNAKA.exemplars,           │
+│             KANNAKA.exemplar.*,          │
 │             QUEEN.phase.*,               │
 │             queen.event.dream.*          │
 └─┬─────────────┬──────────────┬───────────┘

--- a/docs/nats-contract.yaml
+++ b/docs/nats-contract.yaml
@@ -213,19 +213,24 @@ KANNAKA.reactions:
     score audience engagement, drive resonance loops, or feed
     audience-aware narration prompts.
   required:
+    - schema_version
     - ts
+    - agent_id
     - emoji
     - kind        # "human" | "agent"
   optional:
     - track       # the track's title at moment of reaction
-    - from_id     # anonymous client id
+    - from_id     # anonymous per-session client id for crowd dots —
+                  # NOT the stable publisher identity (that is agent_id)
   field_types:
     emoji: string
     kind: string  # enum: human|agent
     track: string
   example: |
     {
+      "schema_version": "1.0",
       "ts": 1777730400000,
+      "agent_id": "kannaka-prime",
       "emoji": "🪶",
       "kind": "human",
       "track": "Mountain Top",
@@ -247,17 +252,24 @@ KANNAKA.reactions:
 "queen.event.dream.end":
   description: |
     Fired when a dream cycle completes. Carries the SAME shape
-    as KANNAKA.dreams (it's the same report), but the lighter
-    consumers can subscribe to event-end without parsing the
-    full report.
+    as KANNAKA.dreams (it's the same report) — identical required
+    and optional fields, plus an extra optional `duration_ms`.
+    Lighter consumers can subscribe to event-end and read only the
+    fields they need without parsing the full report.
   required:
     - schema_version
     - ts
     - agent_id
-    - memories_strengthened
-    - memories_faded
+    - cycles
   optional:
+    - memories_strengthened
+    - memories_pruned       # alias: memories_faded
+    - memories_faded        # deprecated alias of memories_pruned
     - hallucinations_created
+    - new_connections
+    - consciousness_before
+    - consciousness_after
+    - emerged
     - duration_ms
 
 # ============================================================

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -126,7 +126,21 @@ impl CouplingBridge {
         self.k_effective = match self.mode {
             CouplingMode::Static => self.config.k_base,
             CouplingMode::MarketMediated => {
-                (self.config.k_base * signal).clamp(self.config.k_min, self.config.k_max)
+                // `f32::clamp` propagates NaN rather than bounding it, so a
+                // non-finite signal used to return NaN coupling for the
+                // affected tick (#41). The mean_signal() half of that issue
+                // was already fixed above by not storing the sample; this
+                // covers the coupling half. A garbage sample means "no new
+                // information", so hold the last good coupling.
+                if signal.is_finite() {
+                    (self.config.k_base * signal).clamp(self.config.k_min, self.config.k_max)
+                } else if self.k_effective.is_finite() {
+                    self.k_effective
+                } else {
+                    self.config
+                        .k_base
+                        .clamp(self.config.k_min, self.config.k_max)
+                }
             }
             CouplingMode::Adaptive => {
                 // Reject a non-finite coherence sample (#19). Without this, a
@@ -409,6 +423,39 @@ mod tests {
             "mean over finite samples 2 and 4 = 3, got {}",
             bridge.mean_signal()
         );
+    }
+
+    #[test]
+    fn market_mediated_holds_coupling_on_non_finite_signal() {
+        // Regression for #41 — f32::clamp propagates NaN instead of
+        // bounding it, so `k_base * NaN` came straight back out of
+        // update() as NaN coupling for the affected tick.
+        let mut bridge = CouplingBridge::new(
+            BridgeConfig {
+                k_base: 1.0,
+                k_min: 0.1,
+                k_max: 5.0,
+                ..Default::default()
+            },
+            CouplingMode::MarketMediated,
+        );
+        let good = bridge.update(2.0, 0.5);
+        assert!((good - 2.0).abs() < 1e-5);
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let k = bridge.update(bad, 0.5);
+            assert!(
+                k.is_finite(),
+                "signal {bad} must not yield NaN coupling: {k}"
+            );
+            assert!(
+                (k - good).abs() < 1e-6,
+                "coupling should hold at the last good value on signal {bad}: {good} → {k}"
+            );
+        }
+        // A later valid sample still steers coupling normally.
+        let recovered = bridge.update(3.0, 0.5);
+        assert!((recovered - 3.0).abs() < 1e-5);
+        assert!(bridge.mean_signal().is_finite());
     }
 
     #[test]

--- a/src/iit.rs
+++ b/src/iit.rs
@@ -152,13 +152,17 @@ pub struct PhiNode {
 pub fn compute_phi(nodes: &[PhiNode]) -> PhiReport {
     let n = nodes.len() as f32;
     if n < 2.0 {
+        // Φ is genuinely zero below two nodes, but the structural metadata
+        // must still describe the input: a one-node graph has exactly one
+        // partition, and reporting 0 made it indistinguishable from an
+        // empty graph for anything inspecting `num_partitions` (#53).
         return PhiReport {
             phi: 0.0,
             integration: 0.0,
             differentiation: 0.0,
             density_factor: 0.0,
             scale_factor: 0.0,
-            num_partitions: 0,
+            num_partitions: nodes.len().min(1),
             num_connections: 0,
         };
     }
@@ -292,6 +296,23 @@ mod tests {
             connections: vec![],
         }]);
         assert_eq!(report.phi, 0.0);
+    }
+
+    #[test]
+    fn single_node_reports_one_partition() {
+        // Regression for #53 — Φ is legitimately 0 below two nodes, but
+        // reporting num_partitions = 0 made a one-node graph structurally
+        // indistinguishable from an empty one.
+        let one = compute_phi(&[PhiNode {
+            partition: 7,
+            connections: vec![],
+        }]);
+        assert_eq!(one.phi, 0.0, "Φ stays zero for a single node");
+        assert_eq!(one.num_partitions, 1, "one node is one partition");
+        assert_eq!(one.num_connections, 0);
+
+        let empty = compute_phi(&[]);
+        assert_eq!(empty.num_partitions, 0, "an empty graph has no partitions");
     }
 
     #[test]

--- a/src/kuramoto.rs
+++ b/src/kuramoto.rs
@@ -98,6 +98,22 @@ impl Default for KuramotoConfig {
     }
 }
 
+/// Fold a phase back into the documented `[0, 2π)` range.
+///
+/// Non-finite input is returned untouched — callers quarantine those
+/// rather than silently mapping them onto a real angle.
+fn wrap_phase(phase: f32) -> f32 {
+    if !phase.is_finite() {
+        return phase;
+    }
+    let wrapped = phase % TAU;
+    if wrapped < 0.0 {
+        wrapped + TAU
+    } else {
+        wrapped
+    }
+}
+
 /// The Kuramoto synchronization model.
 pub struct KuramotoModel {
     pub config: KuramotoConfig,
@@ -220,6 +236,20 @@ impl KuramotoModel {
         // could still drag down the report.
         let initial_order = Self::order_parameter(oscillators).r;
 
+        // Quarantine oscillators carrying non-finite state (#58). A single
+        // NaN/±inf phase or frequency used to poison the whole round: it
+        // reaches every peer through `sin(phases[j] - phases[i])`, turns
+        // every `dphi` into NaN, and overwrites the healthy oscillators'
+        // phases on the very first Euler step. Invalid oscillators are now
+        // excluded from both sides of the coupling sum and are never
+        // integrated, so their bad value stays visible to the caller
+        // instead of spreading. `order_parameter` already filters them out
+        // of the reported metric.
+        let valid: Vec<bool> = oscillators
+            .iter()
+            .map(|o| o.phase.is_finite() && o.frequency.is_finite())
+            .collect();
+
         let nf = n as f32;
         let mut prev_order = initial_order;
 
@@ -229,22 +259,36 @@ impl KuramotoModel {
 
             let mut dphi = vec![0.0f32; n];
             for i in 0..n {
+                if !valid[i] {
+                    continue;
+                }
                 let mut coupling_sum = 0.0f32;
                 for j in 0..n {
-                    if i != j {
+                    if i != j && valid[j] {
                         let w = match weights {
                             Some(ws) => ws[i][j],
                             None => 1.0,
                         };
-                        coupling_sum += w * (phases[j] - phases[i]).sin();
+                        // A non-finite matrix entry is as poisonous as a
+                        // non-finite phase; treat it as "no coupling".
+                        if w.is_finite() {
+                            coupling_sum += w * (phases[j] - phases[i]).sin();
+                        }
                     }
                 }
                 dphi[i] = freqs[i] + (self.config.coupling_strength / nf) * coupling_sum;
             }
 
-            // Euler integration
+            // Euler integration, then fold the phase back into [0, TAU).
+            // `sin`/`cos` are 2π-periodic so wrapping changes no dynamics,
+            // but without it raw accumulation walks past the documented
+            // `θ ∈ [0, 2π)` contract that `QUEEN.phase.*` publishes and
+            // that `mean_field_step` already honors (#62).
             for i in 0..n {
-                oscillators[i].phase += dphi[i] * self.config.dt;
+                if !valid[i] {
+                    continue;
+                }
+                oscillators[i].phase = wrap_phase(oscillators[i].phase + dphi[i] * self.config.dt);
             }
 
             let current_order = Self::order_parameter(oscillators).r;
@@ -289,10 +333,7 @@ impl KuramotoModel {
         let kuramoto =
             self.config.coupling_strength * order.r * (order.psi - oscillator.phase).sin();
         let d_phase = oscillator.frequency + kuramoto + chiral_term;
-        oscillator.phase = (oscillator.phase + d_phase * self.config.dt) % TAU;
-        if oscillator.phase < 0.0 {
-            oscillator.phase += TAU;
-        }
+        oscillator.phase = wrap_phase(oscillator.phase + d_phase * self.config.dt);
     }
 
     /// Detect hives (clusters of phase-locked oscillators).
@@ -645,6 +686,103 @@ mod tests {
                 op.r
             );
         }
+    }
+
+    #[test]
+    fn sync_quarantines_non_finite_phase_from_healthy_peers() {
+        // Regression for #58 — one NaN phase used to reach every peer
+        // through sin(phases[j] - phases[i]), turn every dphi into NaN, and
+        // overwrite the healthy oscillators on the first Euler step.
+        let model = KuramotoModel::new(KuramotoConfig {
+            coupling_strength: 1.0,
+            dt: 0.1,
+            max_steps: 3,
+            convergence_threshold: 1e-6,
+        });
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let mut oscs = vec![
+                Oscillator::new(0.0, 0.0),
+                Oscillator::new(bad, 0.0),
+                Oscillator::new(1.0, 0.0),
+            ];
+            let report = model.sync(&mut oscs, None);
+            assert!(
+                oscs[0].phase.is_finite() && oscs[2].phase.is_finite(),
+                "healthy peers must survive a {bad} neighbour: {:?}",
+                oscs.iter().map(|o| o.phase).collect::<Vec<_>>()
+            );
+            assert!(
+                report.initial_order.is_finite() && report.final_order.is_finite(),
+                "SyncReport must stay finite alongside a {bad} oscillator"
+            );
+        }
+    }
+
+    #[test]
+    fn sync_quarantines_non_finite_frequency() {
+        // A non-finite *frequency* poisons dphi just as surely as a
+        // non-finite phase, and it survived the phase-only filter (#58).
+        let model = KuramotoModel::default();
+        let mut oscs = vec![
+            Oscillator::new(0.0, 0.0),
+            Oscillator::new(0.5, f32::NAN),
+            Oscillator::new(1.0, 0.0),
+        ];
+        model.sync(&mut oscs, None);
+        assert!(oscs[0].phase.is_finite() && oscs[2].phase.is_finite());
+    }
+
+    #[test]
+    fn sync_leaves_phases_wrapped_into_tau_range() {
+        // Regression for #62 — raw Euler accumulation walked phases well
+        // past TAU (the issue reported 9.23 rad), breaking the documented
+        // `θ ∈ [0, 2π)` contract that QUEEN.phase.* publishes and that
+        // mean_field_step already honored.
+        let model = KuramotoModel::new(KuramotoConfig {
+            coupling_strength: 0.0,
+            dt: 1.0,
+            max_steps: 3,
+            convergence_threshold: 0.0,
+        });
+        let mut oscs = vec![
+            Oscillator::new(TAU - 0.05, 1.0),
+            Oscillator::new(0.10, 1.0),
+            // Negative drift must land in range too, not at -0.3.
+            Oscillator::new(0.1, -2.0),
+        ];
+        model.sync(&mut oscs, None);
+        for (i, o) in oscs.iter().enumerate() {
+            assert!(
+                (0.0..TAU).contains(&o.phase),
+                "osc[{i}].phase must be wrapped into [0, TAU); got {}",
+                o.phase
+            );
+        }
+    }
+
+    #[test]
+    fn wrapping_does_not_change_reported_order() {
+        // sin/cos are 2π-periodic, so folding the phase is a no-op for the
+        // order parameter. This pins that the #62 wrap did not silently
+        // alter the physics the report describes.
+        let model = KuramotoModel::new(KuramotoConfig {
+            coupling_strength: 2.0,
+            dt: 0.1,
+            max_steps: 50,
+            convergence_threshold: 1e-6,
+        });
+        let mut oscs = vec![
+            Oscillator::new(0.0, 0.0),
+            Oscillator::new(1.0, 0.0),
+            Oscillator::new(2.0, 0.0),
+        ];
+        let report = model.sync(&mut oscs, None);
+        assert!(
+            report.final_order > report.initial_order,
+            "sync still converges after wrapping: {} → {}",
+            report.initial_order,
+            report.final_order
+        );
     }
 
     #[test]

--- a/src/math_ext.rs
+++ b/src/math_ext.rs
@@ -25,6 +25,7 @@ pub trait F32Ext {
     fn abs(self) -> f32;
     fn atan2(self, other: f32) -> f32;
     fn powi(self, n: i32) -> f32;
+    fn rem_euclid(self, rhs: f32) -> f32;
 }
 
 impl F32Ext for f32 {
@@ -67,6 +68,19 @@ impl F32Ext for f32 {
     #[inline]
     fn powi(self, n: i32) -> f32 {
         libm::powf(self, n as f32)
+    }
+    /// Mirrors `std::f32::rem_euclid`: the remainder carries the sign of
+    /// `rhs`, so the result is always non-negative for a positive `rhs`.
+    /// `libm::fmodf` alone keeps the sign of `self`, which would let
+    /// `detect_hives`' circular-distance fold go negative. (#29)
+    #[inline]
+    fn rem_euclid(self, rhs: f32) -> f32 {
+        let r = libm::fmodf(self, rhs);
+        if r < 0.0 {
+            r + libm::fabsf(rhs)
+        } else {
+            r
+        }
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -163,13 +163,20 @@ pub fn xi_repulsive_force(xi_a: &[f32], xi_b: &[f32]) -> f32 {
 /// (repulsion > 0.1) receive a small `repulsion * 0.15` nudge.
 pub fn xi_diversity_boost(base_similarity: f32, xi_a: &[f32], xi_b: &[f32]) -> f32 {
     let repulsion = xi_repulsive_force(xi_a, xi_b);
-    if base_similarity > 0.15 && repulsion > 0.05 {
-        (base_similarity * (1.0 + repulsion * 3.0)).min(1.0)
+    let boosted = if base_similarity > 0.15 && repulsion > 0.05 {
+        base_similarity * (1.0 + repulsion * 3.0)
     } else if repulsion > 0.1 {
-        (base_similarity + repulsion * 0.15).min(1.0)
+        base_similarity + repulsion * 0.15
     } else {
         base_similarity
-    }
+    };
+    // Clamp BOTH ends, not just the ceiling (#54). `cosine_similarity`
+    // legitimately returns down to -1.0 for opposed vectors, and the old
+    // `.min(1.0)` let that negative fall straight through — so a helper
+    // documented as "similarity ∈ [0, 1]" handed ranking code a -1.0.
+    // Opposed vectors are "not similar"; the floor is 0, not a negative
+    // score that inverts ordering heuristics downstream.
+    boosted.clamp(0.0, 1.0)
 }
 
 // ─── Consciousness Metrics ───────────────────────────────────────────────────
@@ -424,6 +431,52 @@ mod tests {
                 "xi out of range for weight={weight}: {xi}"
             );
         }
+    }
+
+    #[test]
+    fn diversity_boost_never_returns_negative() {
+        // Regression for #54 — the helper is documented as returning a
+        // similarity ranking code can treat as [0, 1], but it only had a
+        // `.min(1.0)` ceiling. Opposed vectors give cosine_similarity()
+        // -1.0, which fell straight through and could invert ordering
+        // heuristics downstream.
+        let a = vec![1.0f32, 0.0, 0.0, 0.0];
+        let b = vec![-1.0f32, 0.0, 0.0, 0.0];
+        let base = crate::wave::cosine_similarity(&a, &b);
+        assert!((base - (-1.0)).abs() < 1e-6, "precondition: opposed → -1.0");
+
+        let xa = XiSignature::compute(&a);
+        let xb = XiSignature::compute(&b);
+        let boosted = xa.diversity_boost(&xb, base);
+        assert!(
+            (0.0..=1.0).contains(&boosted),
+            "diversity boost must stay in [0, 1]; got {boosted}"
+        );
+
+        // Sweep the whole legal cosine range through both tiers.
+        for base in [-1.0, -0.5, -0.01, 0.0, 0.2, 0.9, 1.0_f32] {
+            let out = xi_diversity_boost(base, &xa.values, &xb.values);
+            assert!(
+                (0.0..=1.0).contains(&out),
+                "out of range for base={base}: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn diversity_boost_still_amplifies_similar_but_distinct_pairs() {
+        // The #54 clamp must not flatten the tier-1 amplification it was
+        // added around.
+        let a = vec![1.0f32, 0.0, 0.0, 0.0];
+        let b = vec![0.0f32, 1.0, 0.0, 0.0];
+        let xa = XiSignature::compute(&a);
+        let xb = XiSignature::compute(&b);
+        let base = 0.5;
+        let boosted = xi_diversity_boost(base, &xa.values, &xb.values);
+        assert!(
+            boosted >= base,
+            "distinct Xi signatures should not lose their boost: {base} → {boosted}"
+        );
     }
 
     #[test]

--- a/src/wave.rs
+++ b/src/wave.rs
@@ -96,6 +96,17 @@ pub fn compute_strength_with_retrieval(
     let phi = params.phase as f64;
     let lambda = (params.decay_rate as f64).max(0.0);
 
+    // Floor the age at zero (#52). `exp(-λt)` with a negative `t` is a
+    // growth term, so a future timestamp or a little clock skew used to
+    // make a memory *stronger* than its base amplitude — at age -100s with
+    // λ=0.01 the decay factor came out as e ≈ 2.718 instead of ≤ 1. A
+    // not-yet-born memory reads as brand new, never as super-charged.
+    let age_seconds = if age_seconds.is_nan() {
+        0.0
+    } else {
+        age_seconds.max(0.0)
+    };
+
     let wave = (2.0 * PI * f * age_seconds + phi).cos();
     let decay = (-lambda * age_seconds).exp();
     (a * wave * decay) as f32
@@ -219,6 +230,39 @@ mod tests {
         wm.record_retrieval();
         let s1 = wm.strength(0.0);
         assert!(s1 > s0);
+    }
+
+    #[test]
+    fn future_timestamps_do_not_amplify_strength() {
+        // Regression for #52 — exp(-λt) with a negative t is a growth
+        // term, so a future timestamp or a little clock skew made a memory
+        // *stronger* than its base amplitude (age -100s with λ=0.01 gave
+        // 2.718 instead of ≤ 1.0).
+        let params = WaveParams {
+            amplitude: 1.0,
+            frequency: 0.0,
+            phase: 0.0,
+            decay_rate: 0.01,
+        };
+        let baseline = compute_strength(&params, 0.0);
+        for age in [-1.0, -100.0, -86_400.0] {
+            let s = compute_strength(&params, age);
+            assert!(
+                s <= baseline + 1e-6,
+                "future age {age} must not exceed the age-0 baseline {baseline}; got {s}"
+            );
+            assert!((s - baseline).abs() < 1e-6, "future age reads as age 0");
+        }
+        // Retrieval energy rides along the same floor.
+        let boosted = compute_strength_with_retrieval(&params, -500.0, 10);
+        let at_zero = compute_strength_with_retrieval(&params, 0.0, 10);
+        assert!((boosted - at_zero).abs() < 1e-6);
+    }
+
+    #[test]
+    fn nan_age_does_not_produce_nan_strength() {
+        let params = WaveParams::default();
+        assert!(compute_strength(&params, f64::NAN).is_finite());
     }
 
     #[test]

--- a/tests/serde_feature.rs
+++ b/tests/serde_feature.rs
@@ -46,7 +46,7 @@ fn consciousness_level_wire_format_matches_nats_contract() {
 
 #[test]
 fn phi_report_serde_roundtrip() {
-    use consciousness_core::iit::{compute_phi, PhiNode};
+    use consciousness_core::iit::{compute_phi, PhiNode, PhiReport};
     let report = compute_phi(&[
         PhiNode {
             partition: 0,
@@ -62,6 +62,37 @@ fn phi_report_serde_roundtrip() {
     assert!(json.contains("\"phi\""));
     assert!(json.contains("\"integration\""));
     assert!(json.contains("\"num_connections\""));
+    let back: PhiReport = serde_json::from_str(&json).expect("deserialize");
+    assert!((back.phi - report.phi).abs() < 1e-6);
+    assert_eq!(back.num_connections, report.num_connections);
+}
+
+#[test]
+fn vec_bearing_types_roundtrip() {
+    // Regression for the whole serde cluster (#2 #43 #44 #55 #56). Every
+    // type here already carried the right derives; the feature was pulling
+    // serde in with `default-features = false` and no `alloc`, so `Vec<T>`
+    // had no Serialize/Deserialize impl. `PhiNode.connections: Vec<usize>`
+    // and `XiSignature.values: Vec<f32>` failed to compile, which killed
+    // the entire `--features serde` build — including the Vec-free types.
+    // These two are the canaries: if `serde/alloc` is ever dropped from
+    // Cargo.toml, this file stops compiling again.
+    use consciousness_core::iit::PhiNode;
+    use consciousness_core::XiSignature;
+
+    let node = PhiNode {
+        partition: 7,
+        connections: vec![1, 2, 3],
+    };
+    let json = serde_json::to_string(&node).expect("serialize PhiNode");
+    let back: PhiNode = serde_json::from_str(&json).expect("deserialize PhiNode");
+    assert_eq!(back.connections, vec![1, 2, 3]);
+    assert_eq!(back.partition, 7);
+
+    let sig = XiSignature::compute(&[1.0, 0.5, 0.3, 0.2]);
+    let json = serde_json::to_string(&sig).expect("serialize XiSignature");
+    let back: XiSignature = serde_json::from_str(&json).expect("deserialize XiSignature");
+    assert_eq!(back.values, sig.values);
 }
 
 #[test]

--- a/tests/unified_pipeline.rs
+++ b/tests/unified_pipeline.rs
@@ -147,6 +147,39 @@ fn adaptive_bridge_converges_over_time() {
     assert!(k_trace.last().unwrap() <= &5.0);
 }
 
+/// The README's "Use" snippet, verbatim. The previous example did not
+/// compile against any version of this API — it called
+/// `KuramotoModel::new(vec![...])` and `model.sync(dt, k)`, neither of
+/// which exist. Keeping the snippet as a test means it cannot drift again.
+#[test]
+fn readme_kuramoto_example_compiles() {
+    use consciousness_core::kuramoto::KuramotoConfig;
+    use consciousness_core::{KuramotoModel, Oscillator};
+
+    let model = KuramotoModel::new(KuramotoConfig {
+        coupling_strength: 0.6,
+        dt: 0.01,
+        max_steps: 1000,
+        ..Default::default()
+    });
+
+    let mut oscillators = vec![
+        Oscillator::new(0.0, 1.0),
+        Oscillator::new(1.5, 1.05),
+        Oscillator::new(3.0, 0.95),
+    ];
+
+    let report = model.sync(&mut oscillators, None);
+    let r = KuramotoModel::order_parameter(&oscillators).r;
+
+    assert!((0.0..=1.0).contains(&report.final_order));
+    assert!((0.0..=1.0).contains(&r));
+    // The README also promises sync() returns phases wrapped into [0, 2π).
+    for osc in &oscillators {
+        assert!((0.0..core::f32::consts::TAU).contains(&osc.phase));
+    }
+}
+
 /// Re-export contract: every type named in CHANGELOG 0.1.0 public API
 /// must be reachable from the crate root. Uses fully-qualified paths
 /// rather than `use ... as _` imports so clippy doesn't flag the names


### PR DESCRIPTION
Verify-triage of all 34 open issues against HEAD, then a grouped fix pass. **Do not merge — for review.**

## The headline: the serde feature never compiled

Five issues (#2 #43 #44 #55 #56) all reported "the serde feature can't serialize X". Every one of those types already carried the correct `#[cfg_attr(feature = "serde", derive(...))]`. The actual cause was one line in `Cargo.toml`: `serde` is pulled in with `default-features = false` (needed for `no_std`), which drops serde's `Vec`/`String` impls. So `PhiNode.connections: Vec<usize>` and `XiSignature.values: Vec<f32>` failed to compile — and that killed the *entire* `--features serde` build, taking the `Vec`-free types down with it.

This stayed invisible because `tests/serde_feature.rs` is gated on `#![cfg(feature = "serde")]`. Under plain `cargo test` it reported `running 0 tests`, and `cargo test --features serde` didn't compile. The fix is `serde = ["dep:serde", "serde/alloc"]`; those 10 tests now actually execute.

`no_std` was broken too — the earlier `detect_hives` fix reached for `f32::rem_euclid`, which `core` doesn't provide. Added to `F32Ext`.

## Numeric guards

| Issue | Was | Now |
|---|---|---|
| #58 | One NaN phase reached every peer via `sin(phases[j] - phases[i])` and overwrote healthy oscillators on the first Euler step | Non-finite oscillators quarantined from both sides of the coupling sum, never integrated |
| #62 | Raw Euler accumulation walked phases past `2π` (reported 9.23 rad) | Folded into `[0, 2π)`. `sin`/`cos` are 2π-periodic, so no dynamics change — pinned by a test |
| #41 | `f32::clamp` propagates NaN, so `k_base * NaN` came back as NaN coupling | Holds last good coupling. (The `mean_signal()` half was already fixed) |
| #52 | `exp(-λt)` with negative `t` is a growth term — clock skew made memories *stronger* than base amplitude | Age floored at 0 |
| #54 | Promised `[0, 1]` but only had a ceiling, so opposed vectors leaked `-1.0` into ranking code | Clamped both ends |
| #53 | Single-node graph reported `num_partitions: 0`, indistinguishable from empty | 1 for one node, 0 only for empty |

## Docs corrected to match code

The README's usage snippet called `KuramotoModel::new(vec![...])` and `model.sync(dt, k)` — neither exists in any version of this API. Replaced with a working example that is now **compiled as a test** (`readme_kuramoto_example_compiles`) so it can't rot again. Also removed the bind/bundle/permute primitives and the eigendecomposition-Φ claim (neither is implemented) and the bridge-level chiral mode (#61 — chiral lives in `kuramoto`).

NATS contract: reactions carry the shared envelope (#28), `dream.end` matches `KANNAKA.dreams` as its own description claims (#38), dependency map points at the singular `KANNAKA.exemplar.*` subject (#39).

## Gates

```
cargo test --all-features    83 + 10 + 6 passed, 0 failed   (was 71 + 0 + 5)
cargo clippy --all-targets --all-features -- -D warnings    clean
cargo fmt --all --check                                     clean
cargo check --no-default-features                           clean  (was failing)
cargo check --features serde                                clean  (was failing)
```

## Closed separately as already-fixed

18 issues were verify-triaged as already fixed at HEAD and closed with evidence: #11 #27 #30 #31 #32 #33 #34 #37 #40 #42 #45 #46 #47 #48 #49 #50 #51 #57.

## Left open deliberately

Four need a call on the metric definition rather than a guess from me:

- **#35** — `compute_differentiation_xi` returns 0.0 for *any* two vectors, because both signals are variances over pairwise similarities and there's only one pair (variance of one sample about its own mean is always 0). Real bug, but the fix is a decision about what two-vector differentiation should mean (cosine distance? Xi-signature distance?).
- **#60** — mixed-dimension embeddings read as `xi=0` ("no differentiation") rather than surfacing an input error, because `cosine_similarity` returns 0.0 on length mismatch. Needs a call on whether this becomes a `Result`.
- **#36** — `unified_xi()` ignores the struct's `xi` field. The code matches its own documented formula (`Φ × r × K × Ψ`); the question is whether differentiation belongs in the product or the name is wrong.
- **#59** — single-oscillator `sync()` reports `r = 1.0`. Mathematically correct (`|e^{iθ}| = 1`) and there's an explicit test locking it in, but inconsistent with `compute_swarm_phi` returning 0.0 for `n < 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)