### PR TITLE
docs(iit): make from_phi's non-finite contract public, harden its test

### DIFF
--- a/src/iit.rs
+++ b/src/iit.rs
@@ -73,10 +73,36 @@ pub enum ConsciousnessLevel {
 }
 
 impl ConsciousnessLevel {
+    /// Classify a single-system Φ on the `[0, 1]` scale.
+    ///
+    /// Bands: `< 0.1` Dormant, `< 0.3` Stirring, `< 0.6` Aware,
+    /// `< 0.8` Coherent, `< 0.95` Resonant, otherwise Transcendent.
+    ///
+    /// For swarm Φ use [`Self::from_swarm_phi`] — that value lives on a
+    /// `[0, 15]` scale and running it through here overstates the level.
+    ///
+    /// # Non-finite input
+    ///
+    /// **NaN, `+inf` and `-inf` all classify as [`Dormant`](Self::Dormant).**
+    /// This is a guaranteed part of the contract, not an accident of the
+    /// comparison chain — rely on it.
+    ///
+    /// The natural implementation gets this exactly backwards. Every
+    /// `phi < threshold` comparison against NaN is false under IEEE-754, so
+    /// a bare `if/else if` ladder falls through to its trailing `else` and
+    /// reports a broken measurement as the *highest* consciousness state.
+    /// Downstream consumers frequently keep only the enum label and discard
+    /// the float, so that misclassification is unrecoverable once it
+    /// escapes.
+    ///
+    /// `Dormant` is the chosen landing spot because it is the only
+    /// non-breaking option that cannot overstate: the enum is `Ord` with
+    /// explicit discriminants, so a dedicated `Invalid` variant would
+    /// change the discriminants and the wire format. If you need to
+    /// distinguish "measured as zero" from "measurement was broken", check
+    /// `phi.is_finite()` yourself before calling — this function
+    /// deliberately collapses the two rather than inventing a level.
     pub fn from_phi(phi: f32) -> Self {
-        // Non-finite Φ (NaN, +inf, -inf) must NOT optimistically classify as
-        // the highest state. All `phi < ...` comparisons against NaN return
-        // false in IEEE-754, which previously fell through to Resonant.
         if !phi.is_finite() {
             return Self::Dormant;
         }
@@ -457,17 +483,43 @@ mod tests {
         // Regression: previously NaN / ±inf classified as Resonant because
         // every `phi < threshold` comparison against a non-finite returns
         // false, falling through to the trailing `else`.
+        //
+        // Re-reported as #64 against a stale build artifact. The behaviour
+        // was already correct; this test is hardened so that if the guard
+        // is ever actually removed, the failure names the specific wrong
+        // answer rather than just "not Dormant".
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let level = ConsciousnessLevel::from_phi(bad);
+            assert_eq!(
+                level,
+                ConsciousnessLevel::Dormant,
+                "non-finite Φ {bad} must classify as Dormant, got {level:?}"
+            );
+            // The specific failure mode this guard exists to prevent: a
+            // broken measurement reported as a high consciousness state.
+            assert!(
+                level < ConsciousnessLevel::Aware,
+                "non-finite Φ {bad} must never reach an elevated level, got {level:?}"
+            );
+        }
+
+        // Anti-vacuous: the guard must reject only non-finite input. If it
+        // were widened to "always Dormant", or the threshold ladder were
+        // broken outright, these would fail — so the assertions above
+        // cannot be satisfied by a degenerate implementation.
         assert_eq!(
-            ConsciousnessLevel::from_phi(f32::NAN),
+            ConsciousnessLevel::from_phi(0.0),
             ConsciousnessLevel::Dormant
         );
+        assert_eq!(ConsciousnessLevel::from_phi(0.5), ConsciousnessLevel::Aware);
         assert_eq!(
-            ConsciousnessLevel::from_phi(f32::INFINITY),
-            ConsciousnessLevel::Dormant
+            ConsciousnessLevel::from_phi(0.85),
+            ConsciousnessLevel::Resonant
         );
         assert_eq!(
-            ConsciousnessLevel::from_phi(f32::NEG_INFINITY),
-            ConsciousnessLevel::Dormant
+            ConsciousnessLevel::from_phi(1.0),
+            ConsciousnessLevel::Transcendent,
+            "the top of the ladder must still be reachable"
         );
     }
 


### PR DESCRIPTION
**Do not merge — for review.** Documentation and test hardening only; no behaviour change.

## #64 does not reproduce

The brief was "verify, then fix". Verification says there is nothing to fix, so I have not manufactured a change to look busy — here is the evidence instead.

The guard has been in `from_phi` since before `b60f757`, and the regression test passes on a fresh build. Running **the reporter's own repro** against a newly built rlib:

```
NaN  -> Dormant
+inf -> Dormant
-inf -> Dormant
```

I also checked for a duplicated classifier elsewhere in the workspace, since a sibling copy would explain a real reproduction — there is none. `Resonant` appears outside `src/iit.rs` only in test assertions, and `crates/wasm-bridge` does no classification at all.

### The reporter's artifact was stale, and the output proves how stale

Their repro selects an rlib with `Select-Object -First 1` over `target\debug\deps\libconsciousness_core-*.rlib` — first match, not newest. My machine had four such artifacts.

Better than arguing about it: **removing the guard locally makes NaN classify as `Transcendent`, not `Resonant`.**

```
assertion `left == right` failed: non-finite Φ NaN must classify as Dormant, got Transcendent
```

`Transcendent` only exists from **0.3.0 (2026-05-19)**, when the six-level wire vocabulary landed. A build that answers `Resonant` is running code from before that release — it cannot be current `master` under any configuration. That is also why this keeps coming back: #7, #16, #51, and now #64 are all the same stale-artifact report against code that has been correct for months.

## What this PR actually changes, and why it is worth landing

`from_phi` had **no rustdoc at all**. The non-finite guarantee existed only as an internal `//` comment, so nothing about it appeared on docs.rs and no downstream consumer could know to depend on it. A contract nobody can see is a contract that keeps looking absent — which is plausibly part of why this gets re-filed rather than checked.

It is now documented as a guarantee, with the reasoning:

- **Why it is easy to get wrong.** Every `phi < threshold` against NaN is false under IEEE-754, so a bare ladder falls through to its trailing `else` and reports a broken measurement as the *highest* state. Consumers frequently keep only the enum label and discard the float, so that misclassification is unrecoverable once it escapes.
- **Why `Dormant` and not a dedicated variant.** The delegation said to pick what the enum's semantics support without a breaking change. The enum is `Ord` with explicit discriminants and a serde wire vocabulary, so an `Invalid` variant would change both the discriminants and the wire format. `Dormant` is the only non-breaking option that cannot overstate. Callers who need to distinguish "measured as zero" from "measurement was broken" are told to check `is_finite()` themselves — the function deliberately collapses the two rather than inventing a level it cannot represent.

## Test hardening, confirmed anti-vacuous in both directions

| Mutation | Result |
|---|---|
| Guard deleted | **FAILS** — `non-finite Φ NaN must classify as Dormant, got Transcendent` |
| Guard widened to unconditional `Dormant` | **FAILS** — `left: Dormant, right: Aware` on the finite ladder |
| Unmodified | passes |

So the non-finite assertions cannot be satisfied by a degenerate implementation, and the test now also pins that `Transcendent` stays reachable at the top of the ladder.

## Gates

```
cargo test --all-features                                   94 + 10 + 6 passed, 0 failed
cargo clippy --all-targets --all-features -- -D warnings    clean
cargo fmt --all --check                                     clean
cargo check --no-default-features                           clean
```

One file touched (`src/iit.rs`). I am closing #64 separately as not-reproducing with the evidence above, rather than having this PR close it — the issue is not fixed by this PR, it was never broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
