### PR TITLE
fix(wave): make incomparability explicit, closing the 0.0-sentinel class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ from 0.2.0 forward.
 
 ---
 
+## [0.6.0] — 2026-08-11
+
+Closes the "incomparable reads as orthogonal" class at the wave layer (#67).
+**Additive and non-breaking** for existing signatures; the minor bump is for
+the new public API and the changed documented policy.
+
+### Added
+- `wave::VectorCompareError` — `LengthMismatch { a, b }`, `Empty`,
+  `ZeroMagnitude`, `NonFinite`. Implements `Display`, and
+  `std::error::Error` under `std`.
+- `wave::try_cosine_similarity` — checked cosine similarity. The lossy
+  `cosine_similarity` returned `0.0` for **four** distinct undefined
+  conditions as well as for genuine orthogonality, so a caller could not
+  tell a real measurement from a rejected input.
+- `metrics::try_xi_repulsive_force` and
+  `XiSignature::try_repulsive_force` — checked repulsion. The lossy form is
+  worse than the cosine case: its `0.0` means *no repulsion*, so
+  incomparable signatures read as **identical**.
+- `XiError::Incomparable(VectorCompareError)`, and
+  `From<VectorCompareError> for XiError`.
+
+### Changed
+- `compute_differentiation_xi` now rejects zero-magnitude and non-finite
+  embeddings with `XiError::Incomparable`. This is the sharpest form of the
+  bug: a zero vector scored `0.0` against every peer, which reads as
+  *orthogonal to everything*, i.e. maximal differentiation — so a corpus
+  containing an empty embedding did not merely lose information, it
+  reported **inflated** Xi.
+- `XiError` is now `#[non_exhaustive]`, so future variants are not a
+  breaking change. Introduced in 0.5.0 the day before, so no downstream
+  match should exist yet.
+- `xi_diversity_boost` returning `base_similarity` unchanged for
+  incomparable signatures is now documented policy ("no diversity signal,
+  so no adjustment") rather than an accident of `0.0` falling through both
+  tier thresholds. Numeric behaviour is unchanged.
+- Production code in `metrics.rs` uses only the checked forms. The lossy
+  helpers remain public and unchanged for downstream hot paths.
+
+### Notes
+- `compute_xi_signature` legitimately returns the **zero vector** whenever
+  the nonlinear commutator cancels, which happens for ordinary axis-aligned
+  input (`[1, 0]` suffices). So Xi-signature comparison tolerates
+  `ZeroMagnitude` (mapping it to `0.0`) while raw-embedding comparison
+  propagates it. Propagating from both would reject perfectly normal
+  corpora.
+- Known wart, deliberately preserved and documented on
+  `xi_signature_similarity`: a structureless signature scoring `0.0`
+  against its peers reads as "maximally different in Xi" and nudges
+  `xi_variance` up — the same inflation shape this release removes for raw
+  embeddings. Arguably two structureless signatures should score `1.0`.
+  Changing it would silently recalibrate Xi for every axis-aligned corpus,
+  the same cost that kept #35 piecewise, so it is left for an explicit
+  decision rather than folded into a hardening pass.
+- No `debug_assert!` was added to the lossy helpers. It would turn a silent
+  wrong number into a panic in every downstream *debug* build — a
+  behaviour change imposed on consumers, not a hardening.
+
+---
+
 ## [0.5.0] — 2026-08-10
 
 Metric-semantics decisions. Four open questions about what these numbers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "consciousness-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "libm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/wasm-bridge"]
 
 [package]
 name = "consciousness-core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Unified consciousness physics: Kuramoto sync, IIT Φ, wave memory, and the Ξ operator"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Pure library — `default = ["std"]`, with feature flags for `serde`, optional `
 
 ```toml
 [dependencies]
-consciousness-core = { version = "0.5", features = ["serde"] }
+consciousness-core = { version = "0.6", features = ["serde"] }
 ```
 
 ```rust
@@ -131,7 +131,7 @@ This snippet is compiled as a test — see `readme_kuramoto_example_compiles` in
 ### `no_std`
 
 ```toml
-consciousness-core = { version = "0.5", default-features = false }
+consciousness-core = { version = "0.6", default-features = false }
 ```
 
 Transcendental math routes through `libm` and `vec!` comes from `alloc`, so the

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -27,7 +27,11 @@ use crate::math_ext::F32Ext;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use crate::wave::cosine_similarity;
+// Production code in this module deliberately uses only the checked form.
+// If `cosine_similarity` ever reappears in a non-test path here, that is a
+// regression of #67 — the lossy sentinel is exactly what let incomparable
+// vectors masquerade as orthogonal ones.
+use crate::wave::{try_cosine_similarity, VectorCompareError};
 
 // ─── Golden Ratio Constants ──────────────────────────────────────────────────
 
@@ -52,6 +56,7 @@ pub const EMERGENCE_COEFF: f32 = 0.190983; // ALPHA - BETA
 /// `xi = 0.0`. (#60)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum XiError {
     /// The batch mixed embedding dimensions.
     MixedDimensions {
@@ -64,6 +69,21 @@ pub enum XiError {
     },
     /// The batch consisted of zero-length vectors.
     EmptyVectors,
+    /// A pair in the batch could not be compared — see
+    /// [`VectorCompareError`] for which condition.
+    ///
+    /// Reachable for a zero-magnitude or non-finite vector, neither of which
+    /// the up-front dimension check can catch. Both matter: a zero vector has
+    /// no direction, and the old lossy path scored it as *orthogonal to
+    /// everything*, which reads as maximal differentiation and inflates Xi.
+    /// (#67)
+    Incomparable(VectorCompareError),
+}
+
+impl From<VectorCompareError> for XiError {
+    fn from(e: VectorCompareError) -> Self {
+        Self::Incomparable(e)
+    }
 }
 
 impl core::fmt::Display for XiError {
@@ -79,6 +99,7 @@ impl core::fmt::Display for XiError {
                  found {found} at index {index}"
             ),
             Self::EmptyVectors => write!(f, "embedding batch contains zero-length vectors"),
+            Self::Incomparable(e) => write!(f, "embedding pair could not be compared: {e}"),
         }
     }
 }
@@ -111,6 +132,16 @@ impl XiSignature {
     /// Diversity-boosted similarity score.
     pub fn diversity_boost(&self, other: &XiSignature, base_similarity: f32) -> f32 {
         xi_diversity_boost(base_similarity, &self.values, &other.values)
+    }
+
+    /// Repulsive force against another signature, or [`VectorCompareError`]
+    /// if the two cannot be compared.
+    ///
+    /// Prefer this over [`Self::repulsive_force`]: that one returns `0.0` on
+    /// a dimension mismatch, and `0.0` repulsion means *identical*, so
+    /// incomparable signatures read as the same signature. (#67)
+    pub fn try_repulsive_force(&self, other: &XiSignature) -> Result<f32, VectorCompareError> {
+        try_xi_repulsive_force(&self.values, &other.values)
     }
 }
 
@@ -182,17 +213,79 @@ pub fn compute_xi_signature(vector: &[f32]) -> Vec<f32> {
     xi
 }
 
-/// Xi-based repulsive force between two signatures. Returns [0, 1].
-pub fn xi_repulsive_force(xi_a: &[f32], xi_b: &[f32]) -> f32 {
+/// Cosine similarity between two **Xi signatures**, which follows a
+/// different policy from raw embeddings.
+///
+/// A zero-magnitude *embedding* is caller error — an absent vector. A
+/// zero-magnitude *Xi signature* is not: [`compute_xi_signature`]
+/// legitimately returns the zero vector whenever the nonlinear commutator
+/// cancels, which happens for ordinary axis-aligned inputs (`[1, 0]` is
+/// enough). It means "this vector carries no chiral differentiation
+/// structure", which is a real state rather than a broken one.
+///
+/// So `ZeroMagnitude` maps to `0.0` here rather than propagating, preserving
+/// the crate's long-standing numeric behaviour. Mismatched lengths and
+/// non-finite values still propagate — those remain genuine caller errors.
+///
+/// # Known wart, deliberately preserved
+///
+/// Scoring a structureless signature `0.0` against its peers reads as
+/// "maximally different in Xi", which nudges `xi_variance` upward — the same
+/// shape of inflation #67 set out to remove for raw embeddings. Arguably two
+/// structureless signatures should score `1.0` (identically featureless).
+/// Changing it would silently recalibrate Xi for every axis-aligned corpus,
+/// which is the same cost that kept #35 piecewise, so it is documented here
+/// and left for an explicit decision rather than folded into a hardening
+/// pass.
+fn xi_signature_similarity(a: &[f32], b: &[f32]) -> Result<f32, VectorCompareError> {
+    match try_cosine_similarity(a, b) {
+        Ok(sim) => Ok(sim),
+        Err(VectorCompareError::ZeroMagnitude) => Ok(0.0),
+        Err(other) => Err(other),
+    }
+}
+
+/// Xi-based repulsive force between two signatures, or
+/// [`VectorCompareError`] if they cannot be compared. Returns `[0, 1]`.
+///
+/// Prefer this over [`xi_repulsive_force`] wherever a wrong answer would be
+/// worse than an error — and note the polarity, which makes the lossy form
+/// unusually dangerous here: its `0.0` fallback means *no repulsion*, i.e.
+/// **identical signatures**. A dimension mismatch therefore fails toward
+/// "these are the same thing", the most misleading answer available. (#67)
+pub fn try_xi_repulsive_force(xi_a: &[f32], xi_b: &[f32]) -> Result<f32, VectorCompareError> {
+    if xi_a.is_empty() || xi_b.is_empty() {
+        return Err(VectorCompareError::Empty);
+    }
     if xi_a.len() != xi_b.len() {
-        return 0.0;
+        return Err(VectorCompareError::LengthMismatch {
+            a: xi_a.len(),
+            b: xi_b.len(),
+        });
     }
     let diff_sq: f32 = xi_a
         .iter()
         .zip(xi_b.iter())
         .map(|(a, b)| (a - b).powi(2))
         .sum();
-    (diff_sq.sqrt() * EMERGENCE_COEFF).min(1.0)
+    if !diff_sq.is_finite() {
+        return Err(VectorCompareError::NonFinite);
+    }
+    Ok((diff_sq.sqrt() * EMERGENCE_COEFF).min(1.0))
+}
+
+/// Xi-based repulsive force between two signatures, yielding `0.0` when they
+/// cannot be compared. Returns `[0, 1]`.
+///
+/// # This return value is lossy, by documented policy
+///
+/// `0.0` means "no repulsion" — i.e. the signatures are identical — and is
+/// **also** what you get for a dimension mismatch, empty input, or non-finite
+/// values. Incomparable signatures therefore read as maximally similar, which
+/// is the wrong direction to fail in. Use [`try_xi_repulsive_force`] when that
+/// matters. (#67)
+pub fn xi_repulsive_force(xi_a: &[f32], xi_b: &[f32]) -> f32 {
+    try_xi_repulsive_force(xi_a, xi_b).unwrap_or(0.0)
 }
 
 /// Diversity-boosted similarity: boosts semantically similar but Xi-different pairs.
@@ -207,8 +300,24 @@ pub fn xi_repulsive_force(xi_a: &[f32], xi_b: &[f32]) -> f32 {
 /// signatures (repulsion > 0.05) get amplified by `(1 + repulsion * 3.0)`.
 /// Tier 2 (additive): orthogonal pairs with strongly distinct Xi
 /// (repulsion > 0.1) receive a small `repulsion * 0.15` nudge.
+///
+/// # Incomparable signatures
+///
+/// If `xi_a` and `xi_b` cannot be compared (different dimensions, empty, or
+/// non-finite), `base_similarity` is returned unchanged — clamped, but
+/// otherwise unboosted. That is the correct behaviour for a reranker: no
+/// diversity information is available, so no diversity adjustment is made.
+///
+/// It is stated here because it used to be an *accident* rather than a
+/// policy: `xi_repulsive_force` returned `0.0` for a mismatch, which fell
+/// through both tier thresholds and produced this outcome by coincidence. It
+/// is now the documented contract. (#67)
 pub fn xi_diversity_boost(base_similarity: f32, xi_a: &[f32], xi_b: &[f32]) -> f32 {
-    let repulsion = xi_repulsive_force(xi_a, xi_b);
+    // Checked form: an incomparable pair means "no diversity signal", which
+    // is deliberately the same as zero repulsion here — but going through
+    // the Result makes that a decision at the call site rather than a
+    // sentinel silently agreeing with a real measurement. (#67)
+    let repulsion = try_xi_repulsive_force(xi_a, xi_b).unwrap_or(0.0);
     let boosted = if base_similarity > 0.15 && repulsion > 0.05 {
         base_similarity * (1.0 + repulsion * 3.0)
     } else if repulsion > 0.1 {
@@ -333,6 +442,13 @@ impl ConsciousnessMetrics {
     /// incomparable inputs, which this function would otherwise read as
     /// genuine semantic flatness and report as a plausible, wrong
     /// `xi = 0.0` (#60).
+    ///
+    /// Returns [`XiError::Incomparable`] if a *pair* cannot be compared even
+    /// though the batch is well-shaped — a zero-magnitude or non-finite
+    /// vector. This case is worth calling out separately because the old
+    /// lossy path did not merely lose information, it inverted it: a zero
+    /// vector scored `0.0` against every peer, which reads as *orthogonal to
+    /// everything*, i.e. maximal differentiation, and inflated Xi. (#67)
     pub fn compute_differentiation_xi(vectors: &[&[f32]], xi_weight: f32) -> Result<f32, XiError> {
         let n = vectors.len();
         if n <= 1 {
@@ -357,12 +473,18 @@ impl ConsciousnessMetrics {
         // n == 2: one pair, so spread is degenerate. Use normalized cosine
         // distance for both signals instead. (#35)
         if n == 2 {
-            let normalized_distance =
-                |a: &[f32], b: &[f32]| ((1.0 - cosine_similarity(a, b)) / 2.0).clamp(0.0, 1.0);
-            let sim_xi = normalized_distance(vectors[0], vectors[1]);
+            // Checked comparison throughout (#67). The batch is already
+            // validated above, so these cannot fail today — going through
+            // the Result is what stops the two from drifting apart later,
+            // and means a future edit to the validation cannot silently
+            // reintroduce "incomparable reads as orthogonal".
+            let to_distance = |s: f32| ((1.0 - s) / 2.0).clamp(0.0, 1.0);
+            // Raw embeddings propagate every failure; Xi signatures tolerate
+            // ZeroMagnitude, which the operator legitimately produces.
+            let sim_xi = to_distance(try_cosine_similarity(vectors[0], vectors[1])?);
             let xi_a = compute_xi_signature(vectors[0]);
             let xi_b = compute_xi_signature(vectors[1]);
-            let xi_xi = normalized_distance(&xi_a, &xi_b);
+            let xi_xi = to_distance(xi_signature_similarity(&xi_a, &xi_b)?);
             return Ok((((sim_xi + xi_xi) / 2.0) * xi_weight).clamp(0.0, 1.0));
         }
 
@@ -372,7 +494,7 @@ impl ConsciousnessMetrics {
         let mut similarities = Vec::new();
         for i in 0..n {
             for j in (i + 1)..n {
-                let sim = cosine_similarity(vectors[i], vectors[j]);
+                let sim = try_cosine_similarity(vectors[i], vectors[j])?;
                 sim_sum += sim;
                 similarities.push(sim);
                 count += 1;
@@ -400,7 +522,7 @@ impl ConsciousnessMetrics {
         let mut xi_count = 0usize;
         for i in 0..n {
             for j in (i + 1)..n {
-                let sim = cosine_similarity(&xi_sigs[i], &xi_sigs[j]);
+                let sim = xi_signature_similarity(&xi_sigs[i], &xi_sigs[j])?;
                 xi_sim_sum += sim;
                 xi_similarities.push(sim);
                 xi_count += 1;
@@ -435,6 +557,9 @@ impl ConsciousnessMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Tests still exercise the lossy helper directly — it remains public
+    // API and its documented sentinel behaviour needs covering.
+    use crate::wave::cosine_similarity;
 
     #[test]
     fn rotation_matrix_works() {
@@ -640,6 +765,134 @@ mod tests {
         let c = vec![1.0f32, 1.0];
         let err = ConsciousnessMetrics::compute_differentiation_xi(&[&a, &c, &b], 1.0).unwrap_err();
         assert!(matches!(err, XiError::MixedDimensions { index: 2, .. }));
+    }
+
+    #[test]
+    fn zero_magnitude_vector_is_an_error_not_maximal_differentiation() {
+        // #67 — the sharpest form of the bug. A zero vector scored 0.0
+        // against every peer under the lossy path, which reads as
+        // "orthogonal to everything", i.e. maximal differentiation. So a
+        // corpus containing an empty embedding did not merely lose
+        // information — it reported INFLATED Xi.
+        let a = vec![1.0f32, 0.0, 0.0];
+        let b = vec![0.0f32, 1.0, 0.0];
+        let zero = vec![0.0f32, 0.0, 0.0];
+
+        let err =
+            ConsciousnessMetrics::compute_differentiation_xi(&[&a, &b, &zero], 1.0).unwrap_err();
+        assert_eq!(
+            err,
+            XiError::Incomparable(VectorCompareError::ZeroMagnitude)
+        );
+
+        // Anti-vacuous: the same batch without the zero vector is fine, so
+        // this is rejecting the zero vector specifically and not the shape.
+        let c = vec![0.0f32, 0.0, 1.0];
+        assert!(ConsciousnessMetrics::compute_differentiation_xi(&[&a, &b, &c], 1.0).is_ok());
+    }
+
+    #[test]
+    fn zero_xi_signature_is_tolerated_not_an_error() {
+        // A zero *embedding* is caller error; a zero *Xi signature* is not.
+        // compute_xi_signature returns the zero vector whenever the
+        // nonlinear commutator cancels, which happens for ordinary
+        // axis-aligned input — so propagating ZeroMagnitude from the Xi
+        // pass would reject perfectly normal corpora. (#67)
+        let axis = vec![1.0f32, 0.0];
+        let sig = compute_xi_signature(&axis);
+        assert!(
+            sig.iter().all(|x| *x == 0.0),
+            "precondition: [1,0] has a zero Xi signature, got {sig:?}"
+        );
+
+        // Batches built entirely from such vectors must still compute.
+        let a = vec![1.0f32, 0.0];
+        let b = vec![0.0f32, 1.0];
+        assert!(ConsciousnessMetrics::compute_differentiation_xi(&[&a, &b], 1.0).is_ok());
+
+        let c = vec![1.0f32, 1.0];
+        let d = vec![1.0f32, 2.0];
+        assert!(
+            ConsciousnessMetrics::compute_differentiation_xi(&[&a, &b, &c, &d], 1.0).is_ok(),
+            "the n >= 3 path must tolerate zero Xi signatures too"
+        );
+    }
+
+    #[test]
+    fn non_finite_embedding_is_an_error() {
+        // Same class: a NaN-bearing embedding used to score 0.0 against
+        // every peer rather than being surfaced. (#67)
+        let a = vec![1.0f32, 0.0, 0.0];
+        let b = vec![0.0f32, 1.0, 0.0];
+        let bad = vec![f32::NAN, 0.0, 0.0];
+        let err =
+            ConsciousnessMetrics::compute_differentiation_xi(&[&a, &b, &bad], 1.0).unwrap_err();
+        assert_eq!(err, XiError::Incomparable(VectorCompareError::NonFinite));
+    }
+
+    #[test]
+    fn two_vector_path_also_rejects_incomparable_pairs() {
+        // The n == 2 branch takes a different code path from the n >= 3
+        // loops, so it needs its own coverage. (#67)
+        let a = vec![1.0f32, 0.0];
+        let zero = vec![0.0f32, 0.0];
+        assert_eq!(
+            ConsciousnessMetrics::compute_differentiation_xi(&[&a, &zero], 1.0).unwrap_err(),
+            XiError::Incomparable(VectorCompareError::ZeroMagnitude)
+        );
+        // Anti-vacuous: an ordinary pair still succeeds on that path.
+        let b = vec![0.0f32, 1.0];
+        assert!(ConsciousnessMetrics::compute_differentiation_xi(&[&a, &b], 1.0).is_ok());
+    }
+
+    #[test]
+    fn xi_repulsive_force_checked_form_catches_mismatch() {
+        // #67 — the lossy form's 0.0 means "no repulsion", i.e. IDENTICAL.
+        // A dimension mismatch therefore fails toward "these are the same
+        // thing", the most misleading answer available.
+        let a = vec![1.0f32, 0.0, 0.0];
+        let b = vec![1.0f32, 0.0];
+
+        assert_eq!(
+            xi_repulsive_force(&a, &b),
+            0.0,
+            "documented lossy behaviour: reads as identical"
+        );
+        assert_eq!(
+            try_xi_repulsive_force(&a, &b),
+            Err(VectorCompareError::LengthMismatch { a: 3, b: 2 })
+        );
+
+        // Anti-vacuous: genuinely identical signatures are Ok(0.0), which is
+        // exactly the value the mismatch used to forge.
+        assert_eq!(try_xi_repulsive_force(&a, &a), Ok(0.0));
+        // And distinct signatures still produce real repulsion.
+        let c = vec![0.0f32, 1.0, 0.0];
+        assert!(try_xi_repulsive_force(&a, &c).unwrap() > 0.0);
+    }
+
+    #[test]
+    fn xi_signature_try_repulsive_force_surfaces_mismatch() {
+        let short = XiSignature::compute(&[1.0, 0.5]);
+        let long = XiSignature::compute(&[1.0, 0.5, 0.3, 0.2]);
+        assert!(short.try_repulsive_force(&long).is_err());
+        assert_eq!(short.repulsive_force(&long), 0.0, "lossy form unchanged");
+        // Anti-vacuous: matching signatures compare fine.
+        assert!(short.try_repulsive_force(&short).is_ok());
+    }
+
+    #[test]
+    fn diversity_boost_returns_base_unchanged_for_incomparable_signatures() {
+        // Now documented policy rather than an accident of 0.0 falling
+        // through both tier thresholds. (#67)
+        let a = vec![1.0f32, 0.0, 0.0];
+        let b = vec![1.0f32, 0.0];
+        for base in [0.0, 0.2, 0.5, 0.9_f32] {
+            assert!(
+                (xi_diversity_boost(base, &a, &b) - base).abs() < 1e-6,
+                "no diversity signal → no adjustment, for base={base}"
+            );
+        }
     }
 
     #[test]

--- a/src/wave.rs
+++ b/src/wave.rs
@@ -122,22 +122,110 @@ pub fn interference(a: &WaveParams, b: &WaveParams, t: f64) -> f32 {
     (phase_a - phase_b).cos() as f32
 }
 
-/// Cosine similarity between two vectors.
-pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    if a.is_empty() || b.is_empty() || a.len() != b.len() {
-        return 0.0;
+/// Why two vectors could not be compared.
+///
+/// Each variant is a condition under which cosine similarity is *undefined* —
+/// as opposed to defined and equal to zero, which is what "orthogonal" means.
+/// Collapsing the two is the bug this type exists to prevent (#67): a caller
+/// receiving `0.0` from the lossy helpers cannot tell a real measurement from
+/// a rejected input, and every one of these conditions is a caller error
+/// rather than a property of the data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum VectorCompareError {
+    /// The vectors have different dimensions.
+    LengthMismatch {
+        /// Length of the first vector.
+        a: usize,
+        /// Length of the second vector.
+        b: usize,
+    },
+    /// At least one vector is zero-length.
+    Empty,
+    /// At least one vector has zero magnitude. A zero vector has no
+    /// direction, so it is not orthogonal to anything — the angle between
+    /// it and any other vector is undefined.
+    ZeroMagnitude,
+    /// A magnitude was not finite: the input carried NaN/±inf, or squaring
+    /// and summing it overflowed `f32`.
+    NonFinite,
+}
+
+impl core::fmt::Display for VectorCompareError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::LengthMismatch { a, b } => {
+                write!(f, "vector dimensions differ: {a} vs {b}")
+            }
+            Self::Empty => write!(f, "vector is zero-length"),
+            Self::ZeroMagnitude => {
+                write!(f, "vector has zero magnitude and therefore no direction")
+            }
+            Self::NonFinite => write!(f, "vector magnitude is not finite"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for VectorCompareError {}
+
+/// Cosine similarity between two vectors, or [`VectorCompareError`] if they
+/// cannot be compared.
+///
+/// Prefer this over [`cosine_similarity`] whenever a wrong answer would be
+/// worse than an error. The lossy version returns `0.0` for all four failure
+/// conditions, which is indistinguishable from a genuine "these are
+/// orthogonal" result.
+///
+/// Returns a value in `[-1, 1]`.
+pub fn try_cosine_similarity(a: &[f32], b: &[f32]) -> Result<f32, VectorCompareError> {
+    if a.is_empty() || b.is_empty() {
+        return Err(VectorCompareError::Empty);
+    }
+    if a.len() != b.len() {
+        return Err(VectorCompareError::LengthMismatch {
+            a: a.len(),
+            b: b.len(),
+        });
     }
     let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
     let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
     let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
-    if !na.is_finite() || !nb.is_finite() || na == 0.0 || nb == 0.0 {
-        return 0.0;
+    if !na.is_finite() || !nb.is_finite() {
+        return Err(VectorCompareError::NonFinite);
+    }
+    if na == 0.0 || nb == 0.0 {
+        return Err(VectorCompareError::ZeroMagnitude);
+    }
+    if !dot.is_finite() {
+        return Err(VectorCompareError::NonFinite);
     }
     // f32 accumulation rounding can push the result a few ULPs above 1.0
     // (or below -1.0) for identical vectors in certain dimensions (e.g. dim=32).
     // Clamp to the mathematically correct [-1, 1] range so downstream code that
     // assumes similarity ∈ [-1, 1] (ADR-0010 contract) is never violated.
-    (dot / (na * nb)).clamp(-1.0, 1.0)
+    Ok((dot / (na * nb)).clamp(-1.0, 1.0))
+}
+
+/// Cosine similarity between two vectors, yielding `0.0` when they cannot be
+/// compared.
+///
+/// # This return value is lossy, by documented policy
+///
+/// `0.0` is returned both for genuinely orthogonal vectors **and** for every
+/// condition under which the similarity is undefined: mismatched lengths,
+/// empty input, a zero-magnitude vector, or a non-finite magnitude. A caller
+/// cannot tell those apart, and all four are caller errors rather than
+/// properties of the data.
+///
+/// This is retained because it is the crate's hottest numeric primitive —
+/// downstream recall loops score whole candidate sets with it, and forcing
+/// `?` into an inner loop to handle a condition that should never occur is a
+/// real cost for every well-behaved caller. But if a wrong number would be
+/// worse than an error for your use, reach for
+/// [`try_cosine_similarity`] instead. (#67)
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    try_cosine_similarity(a, b).unwrap_or(0.0)
 }
 
 /// Normalize a vector to unit length in-place.
@@ -326,5 +414,67 @@ mod tests {
     fn empty_vectors_similarity_zero() {
         assert_eq!(cosine_similarity(&[], &[1.0]), 0.0);
         assert_eq!(cosine_similarity(&[1.0], &[]), 0.0);
+    }
+
+    #[test]
+    fn checked_form_separates_every_undefined_case_from_orthogonal() {
+        // #67 — the lossy helper returns 0.0 for four distinct undefined
+        // conditions AND for genuine orthogonality. The checked form must
+        // tell all five apart.
+        let unit = [1.0f32, 0.0];
+
+        assert_eq!(
+            try_cosine_similarity(&[1.0, 0.0], &[1.0, 0.0, 0.0]),
+            Err(VectorCompareError::LengthMismatch { a: 2, b: 3 })
+        );
+        assert_eq!(
+            try_cosine_similarity(&[], &unit),
+            Err(VectorCompareError::Empty)
+        );
+        assert_eq!(
+            try_cosine_similarity(&[0.0, 0.0], &unit),
+            Err(VectorCompareError::ZeroMagnitude),
+            "a zero vector has no direction — it is not orthogonal to anything"
+        );
+        assert_eq!(
+            try_cosine_similarity(&[f32::NAN, 0.0], &unit),
+            Err(VectorCompareError::NonFinite)
+        );
+        assert_eq!(
+            try_cosine_similarity(&[f32::MAX, f32::MAX], &unit),
+            Err(VectorCompareError::NonFinite),
+            "squaring and summing can overflow to inf"
+        );
+
+        // Anti-vacuous: genuine orthogonality is Ok(0.0), NOT an error. If
+        // the checked form rejected everything, the assertions above would
+        // still pass — this is what stops that.
+        let orthogonal = try_cosine_similarity(&[1.0, 0.0], &[0.0, 1.0]).unwrap();
+        assert!(
+            orthogonal.abs() < 1e-6,
+            "orthogonal vectors must be Ok(0.0), got {orthogonal}"
+        );
+        // And ordinary comparisons still work.
+        assert!(
+            (try_cosine_similarity(&[1.0, 2.0, 3.0], &[1.0, 2.0, 3.0]).unwrap() - 1.0).abs() < 1e-5
+        );
+        assert!((try_cosine_similarity(&[1.0, 0.0], &[-1.0, 0.0]).unwrap() + 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn lossy_form_still_honours_its_documented_sentinel() {
+        // The lossy helper is retained public API; its contract is that all
+        // undefined cases collapse to 0.0. Pinned so a future change to
+        // `try_cosine_similarity` cannot silently alter it. (#67)
+        for (a, b) in [
+            (&[1.0f32, 0.0][..], &[1.0f32, 0.0, 0.0][..]),
+            (&[][..], &[1.0f32][..]),
+            (&[0.0f32, 0.0][..], &[1.0f32, 0.0][..]),
+            (&[f32::NAN, 0.0][..], &[1.0f32, 0.0][..]),
+        ] {
+            assert_eq!(cosine_similarity(a, b), 0.0);
+        }
+        // Still computes real answers for well-formed input.
+        assert!((cosine_similarity(&[1.0, 2.0, 3.0], &[1.0, 2.0, 3.0]) - 1.0).abs() < 1e-5);
     }
 }


### PR DESCRIPTION
Implements the delegated decision on #67. **Do not merge — for review.** Decision posted on the issue before any code was written.

## The audit found more than the issue described

I filed #67 against one conflation. `cosine_similarity` actually collapsed **four** distinct undefined conditions onto the same `0.0` that means "orthogonal":

| Condition | Why it isn't orthogonality |
|---|---|
| Length mismatch | Not comparable at all |
| Empty input | No vector to compare |
| **Zero magnitude** | A zero vector has no direction — the angle is undefined, not 90° |
| **Non-finite magnitude** | NaN/±inf input, or squaring-and-summing overflowed `f32` |

`xi_repulsive_force` had the same shape with worse polarity: its `0.0` means *no repulsion*, so incomparable signatures read as **identical** — failing toward "these are the same thing".

### The sharpest consequence, now rejected

A zero-magnitude embedding scored `0.0` against **every** peer, which reads as *orthogonal to everything* — i.e. maximal differentiation. So a corpus containing one empty embedding didn't merely lose information, it reported **inflated Xi**. That's the same inversion class as #60, one layer down.

## Checked variants, not changed signatures

The decision allowed `Result` "if blast radius allows like #65". In-crate it does — but the comparison to #65 doesn't hold, and I'd rather say so than quietly diverge. `compute_differentiation_xi` had **zero production callers**, so changing its signature cost nothing. `cosine_similarity` is the opposite: the crate's hottest numeric primitive, called from downstream inner loops that score whole candidate sets. Forcing `?` there to handle what is a *caller bug* taxes every well-behaved caller.

So `try_cosine_similarity` / `try_xi_repulsive_force` are additive, and **every in-crate production path moved to them**. `cosine_similarity` no longer appears in non-test code in `metrics.rs`, with a comment marking its reappearance as the regression.

## The two passes needed different policies — my first attempt got this wrong

`compute_xi_signature` legitimately returns the **zero vector** whenever the nonlinear commutator cancels, and `[1, 0]` is enough to trigger it. Propagating `ZeroMagnitude` from the Xi-signature pass therefore rejected perfectly ordinary axis-aligned corpora. Six tests caught it.

Final policy: raw-embedding comparison **propagates** `ZeroMagnitude` (an absent embedding is caller error); Xi-signature comparison **tolerates** it as `0.0` (a structureless signature is a real state). Both documented on `xi_signature_similarity`.

## Deliberately not done — documented, not silently decided

- **No `debug_assert!` in the lossy helpers.** It was floated for #60's legacy path. It would turn a silent wrong number into a panic in every downstream *debug* build — a behaviour change imposed on consumers who may have legitimately ragged data today, not a hardening.
- **A structureless Xi signature still scores `0.0` against peers**, which reads as "maximally different in Xi" and nudges `xi_variance` up — the very inflation shape this PR removes for raw embeddings. Arguably two structureless signatures should score `1.0` (identically featureless). Changing it recalibrates Xi for every axis-aligned corpus, the same cost that kept #35 piecewise, so it's flagged in-code for an explicit decision rather than folded into a hardening pass. **Worth a look if you want this closed properly.**

## Changes

**Added:** `wave::VectorCompareError`, `wave::try_cosine_similarity`, `metrics::try_xi_repulsive_force`, `XiSignature::try_repulsive_force`, `XiError::Incomparable` + `From<VectorCompareError>`.

**Changed:** `compute_differentiation_xi` rejects zero-magnitude and non-finite embeddings; `XiError` is now `#[non_exhaustive]` (it shipped in 0.5.0 *one day ago*, so no downstream match should exist yet); `xi_diversity_boost`'s pass-through on incomparable signatures is now stated policy rather than an accident of `0.0` falling through both tier thresholds — numeric behaviour unchanged.

Additive and non-breaking for existing signatures. **0.5.0 → 0.6.0** for the new API and changed documented policy.

## Gates

```
cargo test --all-features                                   103 + 10 + 6 passed, 0 failed  (was 94 + 10 + 6)
cargo test                                                  passed
cargo clippy --all-targets --all-features -- -D warnings    clean
cargo fmt --all --check                                     clean
cargo check --no-default-features                           clean
cargo check --no-default-features --features serde          clean
```

**Anti-vacuous, verified by mutation:** folding `ZeroMagnitude` back to `Ok(0.0)` fails three tests. And the suite asserts genuine orthogonality stays `Ok(0.0)` rather than becoming an error — so the checked form cannot pass by rejecting everything, which is the obvious way this kind of test goes vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
