### PR TITLE
docs(contract): exemplar centroid moves required -> optional (kannaka-memory#703)

### DIFF
--- a/docs/nats-contract.yaml
+++ b/docs/nats-contract.yaml
@@ -187,8 +187,18 @@ KANNAKA.dreams:
     - ts
     - agent_id
     - cluster_id
-    - centroid
   optional:
+    # centroid moved required -> optional (kannaka-memory#703). Two reasons,
+    # and the second is the real one:
+    #   1. size — a full wave-memory centroid is WAVEFRONT_DIM floats, and at
+    #      large dims a batch of top-25 cluster snapshots brushes NATS's
+    #      default 1 MB payload cap;
+    #   2. meaning — HRM encodings are PER-AGENT (each agent's encoder maps
+    #      content into its own wave space; divergence is by design). An
+    #      absorbing agent cannot use a foreign centroid: it re-encodes the
+    #      exemplar's CONTENT into its own space. The centroid was never the
+    #      interchange payload — content + content_hash is.
+    - centroid
     - amplitude
     - importance
     - tags


### PR DESCRIPTION
Companion to the publisher-side envelope fix already on kannaka-memory master.

The requirement was wrong by design, not just by size: **HRM encodings are per-agent** — each agent's encoder maps content into its own wave space, and divergence between encoders is deliberate — so an absorbing agent cannot use a foreign centroid. It re-encodes the exemplar's **content** into its own space; `content` + `content_hash` is the interchange payload, and always was. Size seconds the motion: a full centroid is WAVEFRONT_DIM floats, and the top-25 post-dream batch brushes NATS's 1 MB cap at large dims.

With this amendment plus the landed `add_envelope` change, the shipped exemplar payload is fully on-contract. A regression test pinning the envelope keys lands separately in kannaka-memory.